### PR TITLE
fix: Add netanel-core dependency to dashboard requirements

### DIFF
--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,5 +1,7 @@
 # Minimal dependencies for dashboard server only
-# Does not include agent dependencies (netanel-core)
+
+# netanel-core installed from GitHub (will switch to PyPI after publication)
+netanel-core @ git+https://github.com/netanel-systems/netanel-core.git@main
 
 e2b-code-interpreter>=1.0
 httpx>=0.27


### PR DESCRIPTION
## Problem

Dashboard crashes on startup with:
```
ModuleNotFoundError: No module named 'netanel_core'
```

The dashboard imports `brain.py` which requires `netanel-core`, but it wasn't in `requirements-dashboard.txt`.

## Solution

Add `netanel-core` installed from GitHub to `requirements-dashboard.txt`.

Using GitHub URL temporarily until PyPI publication is complete. Will update to PyPI version once published.

## Test Plan

- [ ] Merge this PR
- [ ] Railway redeploys automatically
- [ ] Dashboard starts successfully
- [ ] No ModuleNotFoundError

🤖 Generated with [Claude Code](https://claude.com/claude-code)