### PR TITLE
feat: Use netanel-core from PyPI

### DIFF
--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,6 +1,6 @@
 # Minimal dependencies for dashboard server only
-# Does not include agent dependencies (netanel-core)
 
+netanel-core>=0.1.0
 e2b-code-interpreter>=1.0
 httpx>=0.27
 python-dotenv>=1.0


### PR DESCRIPTION
netanel-core v0.1.0 published to PyPI! 🎉

Updates dashboard requirements to use published version from PyPI.

https://pypi.org/project/netanel-core/