### PR TITLE
fix: use commands.run(background=True) for agent start step (#45)

### DIFF
--- a/src/social_agent/control.py
+++ b/src/social_agent/control.py
@@ -380,6 +380,32 @@ class SandboxController:
         )
         return result.stdout
 
+    def start_background_command(
+        self,
+        sandbox_id: str,
+        command: str,
+        *,
+        envs: dict[str, str] | None = None,
+    ) -> None:
+        """Start a long-running command in the background and return immediately.
+
+        Uses E2B's ``background=True`` mode which returns a ``CommandHandle``
+        without waiting for the process to exit.  Use this for the agent start
+        step where the process is expected to run indefinitely.
+
+        Args:
+            sandbox_id: Target sandbox.
+            command: Shell command to execute.
+            envs: Environment variables to inject into the command.
+        """
+        sbx = Sandbox.connect(sandbox_id, **self._api_params())
+        sbx.commands.run(command, background=True, envs=envs or {})
+        logger.info(
+            "start_background_command: [%s] started in %s",
+            command[:50].replace("\n", " "),
+            sandbox_id,
+        )
+
     # --- Health check ---
 
     def check_health(


### PR DESCRIPTION
## Problem

`lifecycle.py` was starting the agent with `nohup ... &` via `commands.run(timeout=10)`. E2B tracks the entire process group — the shell exits with `&` but the python process keeps running. `commands.run` waited for the python process to exit and always timed out.

Previous deploys appeared to succeed because the agent was immediately crashing (circuit breaker on stale `consecutive_failures`). PR #44 fixed that — now the agent runs properly, and the deploy step always times out with `TimeoutException`.

## Fix

- `control.py`: added `start_background_command()` using `sbx.commands.run(cmd, background=True)` — returns `CommandHandle` immediately, process keeps running
- `lifecycle.py`: agent start step now uses `start_background_command`; `timeout=None` signals non-blocking; `nohup &` removed (not needed)
- `tests/test_control.py`: `TestStartBackgroundCommand` — 5 tests verifying `background=True` is passed, envs forwarded, returns None
- `tests/test_lifecycle.py`: updated deploy tests to assert 2 blocking + 1 background command; 2 new tests for agent start step correctness and failure

## Test Results
439/439 passed

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for non-blocking background command execution, allowing agent deployments to start without waiting for completion.
  * Deployments now execute background tasks without blocking the deployment pipeline.

* **Tests**
  * Added comprehensive test coverage for background command execution and non-blocking deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->