### PR TITLE
fix: set 3600s timeout on E2B sandbox creation

### DIFF
--- a/src/social_agent/lifecycle.py
+++ b/src/social_agent/lifecycle.py
@@ -36,6 +36,7 @@ _MAX_MIGRATIONS_PER_DAY = 10
 _DEFAULT_MIGRATION_THRESHOLD_S = 300  # 5 minutes before expiry
 _DEFAULT_VERIFY_TIMEOUT_S = 120  # 2 minutes to verify successor
 _DEFAULT_VERIFY_POLL_INTERVAL_S = 5  # Poll every 5 seconds
+_SANDBOX_TIMEOUT_S = 3600  # 1 hour — watchdog re-deploys if agent dies
 
 
 @dataclass(frozen=True)
@@ -139,9 +140,15 @@ class LifecycleManager:
             return None
 
         try:
-            sandbox = Sandbox.create(api_key=self.e2b_api_key)
+            sandbox = Sandbox.create(
+                api_key=self.e2b_api_key,
+                timeout=_SANDBOX_TIMEOUT_S,
+            )
             new_id = sandbox.sandbox_id
-            logger.info("Created successor sandbox: %s", new_id)
+            logger.info(
+                "Created successor sandbox: %s (timeout=%ds)",
+                new_id, _SANDBOX_TIMEOUT_S,
+            )
             return new_id
         except Exception:
             logger.exception("Failed to create successor sandbox")

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -191,7 +191,10 @@ class TestCreateSuccessor:
 
         result = lifecycle.create_successor()
         assert result == "sb-new"
-        mock_sandbox_cls.create.assert_called_once_with(api_key="test_key")
+        mock_sandbox_cls.create.assert_called_once_with(
+            api_key="test_key",
+            timeout=3600,
+        )
 
     @patch("social_agent.lifecycle.Sandbox")
     def test_create_failure(


### PR DESCRIPTION
Fixes #51

## What

E2B sandbox was dying every ~5 minutes (default timeout=300s). The watchdog runs every 15 minutes — sandbox died between runs. No external API call resets the timer since the agent runs inside the sandbox.

## Changes

**`src/social_agent/lifecycle.py`**
- Added `_SANDBOX_TIMEOUT_S = 3600` constant
- Pass `timeout=_SANDBOX_TIMEOUT_S` to `Sandbox.create()` in `create_successor()`

**`tests/test_lifecycle.py`**
- Updated `test_create_success` assertion: `assert_called_once_with(api_key=..., timeout=3600)`

## Why 3600
- 1 hour per sandbox — enough for many agent cycles
- Watchdog redeploys within 15 minutes if agent ever dies
- E2B max timeout is 3600s

## Test Plan
- [x] 476/476 tests passing
- [x] `test_create_success` verifies `timeout=3600` is passed to `Sandbox.create()`
- [ ] After merge: trigger watchdog to deploy with new timeout, verify agent runs >5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox creation now includes configurable timeout support for improved resource management.

* **Tests**
  * Updated sandbox creation tests to validate timeout parameter handling in lifecycle workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->