### PR TITLE
fix: use state_path.resolve().parent as brain path for git push

### DIFF
--- a/src/social_agent/agent.py
+++ b/src/social_agent/agent.py
@@ -207,7 +207,7 @@ class Agent:
             if settings.git_sync_enabled and settings.brain_repo_url:
                 from social_agent.git_push import push_state
 
-                brain_path = _Path("~/nathan-brain").expanduser()
+                brain_path = self._state_path.resolve().parent
                 push_state(brain_path, f"agent startup: sandbox_id={self._sandbox_id}")
 
     @property


### PR DESCRIPTION
Fixes #53

## Root Cause

The watchdog clones nathan-brain to `/home/user/brain` and runs the agent from there. `agent.py` derived the brain path with `~/nathan-brain` — which expands to `/home/user/nathan-brain` (a path that never exists in the E2B sandbox).

`push_state()` checks `brain_path.exists()` → returns `False` → exits silently → startup commit never fires → nathan-brain `state.json` never updated → dashboard stuck at `sbx-not-started`.

## Fix

```python
# Before
brain_path = _Path("~/nathan-brain").expanduser()

# After
brain_path = self._state_path.resolve().parent
```

`state.json` lives at `/home/user/brain/state.json`, so `resolve().parent` = `/home/user/brain` — always correct.

## Changes
- `src/social_agent/agent.py`: 1 line — derive brain_path from state_path
- `tests/test_agent.py`: new test `test_git_push_uses_state_path_parent` verifies correct path is passed

## Test Plan
- [x] 477/477 tests passing
- [x] `test_git_push_uses_state_path_parent` verifies `push_state` called with `state_path.resolve().parent`
- [ ] After merge: trigger watchdog → agent should commit `agent startup: sandbox_id=...` to nathan-brain within first cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed git synchronization to correctly resolve the path for storing brain state.

* **Tests**
  * Added tests to verify git synchronization path resolution works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->